### PR TITLE
Added "keep if touse"

### DIFF
--- a/maptile.ado
+++ b/maptile.ado
@@ -174,6 +174,7 @@ program define maptile, rclass
 	* Restrict sample
 	if `"`if'`in'"'!="" {
 		marksample touse
+		qui keep if `touse'
 		qui replace `var'=. if !`touse'
 	}
 


### PR DESCRIPTION
This keeps only the observations specified in the "if/in" statement when doing the mapping, which prevents problems with mapping panel data. Without this, Stata throws an error when it tries to merge in the shapefiles, since the geographic id is not unique. Now, if the geographic id is unique within the observations specified in the "if/in" statement, it works without these errors.
